### PR TITLE
make scripts stricter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: lint
+lint:
+	shellcheck \
+		--exclude=SC2002 \
+		*.sh

--- a/post-reboot.sh
+++ b/post-reboot.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
 # back in, in a new session, check that drivers were set up correctly
 nvidia-smi
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e -u -o pipefail
+
 # following https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
 
 # install docker


### PR DESCRIPTION
Make the setup scripts fail immediately when something breaks.

Add a Make target making it easier to run `shellcheck` over the code.

```shell
make lint
```